### PR TITLE
EXT-139 ⋮ Support removal of iCal links under V2 Views & Blocks

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,11 @@ We're always interested in your feedback and our [premium forums](https://theeve
 
 == Changelog ==
 
+= 1.1.0 2020-02-05 = V2/Block Edition
+
+* Supports hiding iCal links from V2 views.
+* Supports hiding iCal links from block-editor powered events.
+
 = 1.0.0 2018-04-12 = Initial Version
 
 * Initial release

--- a/tribe-ext-remove-export-links.php
+++ b/tribe-ext-remove-export-links.php
@@ -3,7 +3,7 @@
  * Plugin Name:       The Events Calendar Extension: Remove Export Links
  * Plugin URI:        https://theeventscalendar.com/extensions/remove-export-links/
  * Description:       Remove the Export Links from Event Views
- * Version:           1.0.0
+ * Version:           1.1.0
  * Extension Class:   Tribe__Extension__Remove_Export_Links
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-remove-export-links
  * Author:            Modern Tribe, Inc.
@@ -47,10 +47,12 @@ if (
 		 * Extension initialization and hooks.
 		 */
 		public function init() {
-			add_action( 'init', array( $this, 'remove_hooks' ) );
+			add_action( 'init', [ $this, 'remove_for_views_v1' ] );
+			add_filter( 'tribe_template_html', [ $this, 'remove_for_views_v2' ], 10, 3 );
+			add_filter( 'tribe_template_context_get', [ $this, 'remove_for_blocks' ], 10, 2 );
 		}
 
-		public function remove_hooks() {
+		public function remove_for_views_v1() {
 			$provider = $this->ical_provider();
 			/**
 			 * Removes the markup for "+Ical Export" and "+Google Calendar" links on Single Events.
@@ -61,6 +63,32 @@ if (
 			 * Removes the markup for the "+ Export Events" link on Calendar views.
 			 */
 			remove_filter( 'tribe_events_after_footer', array( $provider, 'maybe_add_link' ) );
+		}
+
+		public function remove_for_views_v2( $html, $file, $name ) {
+			if (
+				is_array( $name )
+				&& count( $name ) === 2
+				&& $name[0] === 'components'
+				&& $name[1] === 'ical-link'
+			) {
+				return '';
+			}
+
+			return $html;
+		}
+
+		public function remove_for_blocks( $value, $index ) {
+			if (
+				is_array( $index )
+				&& count( $index ) === 2
+				&& $index[0] === 'attributes'
+				&& $index[1] === 'hasiCal'
+			) {
+				return false;
+			}
+
+			return $value;
 		}
 
 		/**


### PR DESCRIPTION
A customer noted that this extension no longer works with V2 Views / Blocks. This brings it up-to-date without sacrificing support for legacy users.

![bye-bye-ical-v2-no-no](https://user-images.githubusercontent.com/3594411/73889497-37d77880-4846-11ea-95fc-64b4021b472c.gif)

[EXT-139]